### PR TITLE
fixing usemap typo in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,8 @@
           <h4 id="quote-count"></h4>
           <div>
             <!-- <button id="get-quotes">Get Quote</button> -->
-            <img class="circle-arrows" src="./lib/arrows/circle_last.png" width="64" height="64" usemap="lastcircle">
-            <img class="circle-arrows" src="./lib/arrows/circle_next.png" width="64" height="64" usemap="nextcircle">
+            <img class="circle-arrows" src="./lib/arrows/circle_last.png" width="64" height="64" usemap="#lastcircle">
+            <img class="circle-arrows" src="./lib/arrows/circle_next.png" width="64" height="64" usemap="#nextcircle">
             <map name="nextcircle">
               <a id="get-quotes"><area  shape="circle" coords="34,30,32"></a>
             </map>

--- a/public/style/main.css
+++ b/public/style/main.css
@@ -72,7 +72,7 @@ span {
 }
 
 .style-button:active {
-  opacity: 0.8
+  opacity: 0.8;
   color: white;
   font-weight: 200;
 }


### PR DESCRIPTION
typo cleanups in index.html and main.css, the typo in index was preventing the forward and back buttons from functioning in safari